### PR TITLE
Fiz zero-size map edge case in InlineInstances

### DIFF
--- a/src/main/scala/firrtl/passes/Inline.scala
+++ b/src/main/scala/firrtl/passes/Inline.scala
@@ -264,10 +264,15 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
         }
       }
 
-      val maxIdx = indexMap.values.max
-      val resultSeq = Seq.fill(maxIdx + 1)(RenameMap())
-      val resultMap = indexMap.mapValues(idx => resultSeq(maxIdx - idx))
-      (resultMap, resultSeq)
+      indexMap match {
+        case a if a.isEmpty =>
+          (Map.empty[(OfModule, Instance), RenameMap], Seq.empty[RenameMap])
+        case a =>
+          val maxIdx = indexMap.values.max
+          val resultSeq = Seq.fill(maxIdx + 1)(RenameMap())
+          val resultMap = indexMap.mapValues(idx => resultSeq(maxIdx - idx))
+          (resultMap, resultSeq)
+      }
     }
 
     def fixupRefs(
@@ -353,8 +358,11 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
         Some(m.map(onStmt(ModuleName(m.name, CircuitName(c.main)))))
     })
 
-    val renames = renamesSeq.tail.foldLeft(renamesSeq.head)(_ andThen _)
+    val renames = renamesSeq match {
+      case Nil        => None
+      case car :: cdr => Some(cdr.foldLeft(car)(_ andThen _))
+    }
 
-    CircuitState(flatCircuit, LowForm, annos, Some(renames))
+    CircuitState(flatCircuit, LowForm, annos, renames)
   }
 }

--- a/src/test/scala/firrtlTests/FlattenTests.scala
+++ b/src/test/scala/firrtlTests/FlattenTests.scala
@@ -272,4 +272,16 @@ class FlattenTests extends LowTransformSpec {
       """.stripMargin
     execute(input, check, Seq(flatten("Top")))
   }
+
+  "The Flatten transform" should "work on modules with no instances" in {
+    val input = """
+                  |circuit Top :
+                  |  module Top :
+                  |    input a : UInt<32>
+                  |    output b : UInt<32>
+                  |    b <= a
+      """.stripMargin
+    val check = input
+    execute(input, check, Seq(flatten("Top")))
+  }
 }


### PR DESCRIPTION
This is one possible fix for #1868. For the circuit you've found @ekiwi, the `indexMap` is size zero. This patch adds some special casing around that edge case.

This was originally @albertchen-sifive logic from https://github.com/freechipsproject/firrtl/pull/1184, so maybe it's worth having him spot check this.